### PR TITLE
Feature/section

### DIFF
--- a/src/main/java/com/kh/dotogether/configuration/S3Configure.java
+++ b/src/main/java/com/kh/dotogether/configuration/S3Configure.java
@@ -1,5 +1,6 @@
 package com.kh.dotogether.configuration;
 
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+
+
 
 @Configuration
 public class S3Configure {

--- a/src/main/java/com/kh/dotogether/configuration/SecurityConfigure.java
+++ b/src/main/java/com/kh/dotogether/configuration/SecurityConfigure.java
@@ -86,12 +86,18 @@ public class SecurityConfigure {
                 .requestMatchers(HttpMethod.DELETE, "/api/members/{id}",
                 									"/api/teams/join-cancle",
                 									"/api/teams",
-                									"/api/teams/**").authenticated()
+                									"/api/teams/**",
+                									"/api/section",
+                									"/api/section/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/teams",
                 								  "/api/teams/join",
-                								  "/api/teams/join-accept").authenticated()
+                								  "/api/teams/join-accept",
+              									  "/api/section",
+              									  "/api/section/**").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/teams/**",
-                								 "/api/chat").authenticated()
+                								 "/api/chat",
+             									 "/api/section",
+             									 "/api/section/**").authenticated()
                 .requestMatchers("/api/info/**").authenticated()
                 .requestMatchers("/api/profile/**").authenticated()
                 

--- a/src/main/java/com/kh/dotogether/configuration/SecurityConfigure.java
+++ b/src/main/java/com/kh/dotogether/configuration/SecurityConfigure.java
@@ -85,16 +85,22 @@ public class SecurityConfigure {
                 									"/api/teams",
                 									"/api/teams/**",
                 									"/api/section",
-                									"/api/section/**").authenticated()
+                									"/api/section/**",
+                									"/api/schedule",
+                									"/api/schedule/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/teams",
                 								  "/api/teams/join",
                 								  "/api/teams/join-accept",
               									  "/api/section",
-              									  "/api/section/**").authenticated()
+              									  "/api/section/**",
+              									  "/api/schedule",
+            									  "/api/schedule/**").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/teams/**",
                 								 "/api/chat",
              									 "/api/section",
              									 "/api/section/**",
+             									 "/api/schedule",
+            									 "/api/schedule/**",
                 								 "/api/works/**").authenticated()
                 .requestMatchers("/api/info/**").authenticated()
                 .requestMatchers("/api/profile/**").authenticated()

--- a/src/main/java/com/kh/dotogether/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/kh/dotogether/schedule/controller/ScheduleController.java
@@ -1,19 +1,16 @@
 package com.kh.dotogether.schedule.controller;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import com.kh.dotogether.auth.model.vo.CustomUserDetails;
+import com.kh.dotogether.schedule.model.dto.MoveScheduleRequest;
 import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
 import com.kh.dotogether.schedule.model.service.ScheduleService;
-import com.kh.dotogether.section.model.dto.SectionDTO;
 import com.kh.dotogether.util.ResponseData;
 
 import jakarta.validation.Valid;
@@ -27,67 +24,92 @@ import lombok.extern.slf4j.Slf4j;
 public class ScheduleController {
 	
 	private final ScheduleService scheduleService;
-	
+
+	// ✅ 일정 추가
 	@PostMapping
 	public ResponseEntity<ResponseData> setSchedule(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@RequestBody @Valid ScheduleDTO scheduleDTO) {
 
+		scheduleDTO.setUserNo(userDetails.getUserNo()); // 인증 사용자로 덮어쓰기
 		scheduleService.setSchedule(scheduleDTO);
 
 		return ResponseEntity.ok(ResponseData.builder()
-							 .code("200")
-							 .message("일정 추가에 성공했습니다.")
-							 .items(Collections.emptyList())
-							 .build());
+				.code("200")
+				.message("일정 추가에 성공했습니다.")
+				.items(List.of(scheduleDTO))
+				.build());
 	}
 	
+	
+	@PostMapping("/base-section-set")
+	public ResponseEntity<ResponseData> addToBaseSection(
+	    @AuthenticationPrincipal CustomUserDetails userDetails,
+	    @RequestBody @Valid ScheduleDTO scheduleDTO) {
+	    scheduleDTO.setUserNo(userDetails.getUserNo());
+	    scheduleService.setScheduleInBaseSection(scheduleDTO);
+
+	    return ResponseEntity.ok(ResponseData.builder()
+	        .code("200")
+	        .message("기준 섹션에 일정 추가 성공")
+	        .items(List.of(scheduleDTO))
+	        .build());
+	}
+
+
+	// ✅ 일정 조회
 	@GetMapping("/{scheduleNo}")
 	public ResponseEntity<ResponseData> findSchedule(@PathVariable("scheduleNo") Long scheduleNo) {
-	    ScheduleDTO schedule = scheduleService.findScheduleById(scheduleNo);
-	    return ResponseEntity.ok(ResponseData.builder()
-	            .code("200")
-	            .message("일정 상세 조회 성공")
-	            .items(Collections.singletonList(schedule))  // 단일 일정도 리스트로 감싸기
-	            .build());
+		ScheduleDTO schedule = scheduleService.findScheduleById(scheduleNo);
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("일정 상세 조회 성공")
+				.items(Collections.singletonList(schedule))
+				.build());
 	}
-	
-	
+
+	// ✅ 일정 수정
 	@PostMapping("/update")
-	public ResponseEntity<ResponseData> updateSchedule(@RequestBody @Valid ScheduleDTO scheduleDTO) {
+	public ResponseEntity<ResponseData> updateSchedule(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
+			@RequestBody @Valid ScheduleDTO scheduleDTO) {
+
+		scheduleDTO.setUserNo(userDetails.getUserNo()); // 인증 사용자 기준으로 설정
 		scheduleService.updateSchedule(scheduleDTO);
+
 		return ResponseEntity.ok(ResponseData.builder()
 				.code("200")
 				.message("일정 수정 완료")
 				.items(Collections.emptyList())
 				.build());
 	}
-	
+
+	// ✅ 일정 삭제
 	@DeleteMapping("/{scheduleNo}")
-	public ResponseEntity<ResponseData> deleteSection(@PathVariable("scheduleNo") Long scheduleNo) {
-		scheduleService.deleteSchedule(scheduleNo);
+	public ResponseEntity<ResponseData> deleteSection(
+			@PathVariable("scheduleNo") Long scheduleNo,
+			@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userNo = userDetails.getUserNo();
+		scheduleService.deleteSchedule(scheduleNo, userNo); // 서비스에서 소유자 확인도 함께 수행
 		return ResponseEntity.ok(ResponseData.builder()
 				.code("200")
 				.message("일정이 성공적으로 삭제되었습니다.")
 				.items(Collections.emptyList())
 				.build());
 	}
-	
-	
 
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	// ✅ 일정 섹션 이동
+	@PostMapping("/update-schedule-section")
+	public ResponseEntity<ResponseData> updateScheduleSection(
+			@RequestBody MoveScheduleRequest request) {
+
+		scheduleService.updateScheduleSection(request);
+
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("일정 이동 완료")
+				.items(Collections.emptyList())
+				.build());
+	}
 }

--- a/src/main/java/com/kh/dotogether/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/kh/dotogether/schedule/controller/ScheduleController.java
@@ -1,5 +1,93 @@
 package com.kh.dotogether.schedule.controller;
 
-public class ScheduleController {
+import java.util.Collections;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+import com.kh.dotogether.schedule.model.service.ScheduleService;
+import com.kh.dotogether.section.model.dto.SectionDTO;
+import com.kh.dotogether.util.ResponseData;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/schedule")
+@RequiredArgsConstructor
+public class ScheduleController {
+	
+	private final ScheduleService scheduleService;
+	
+	@PostMapping
+	public ResponseEntity<ResponseData> setSchedule(
+			@RequestBody @Valid ScheduleDTO scheduleDTO) {
+
+		scheduleService.setSchedule(scheduleDTO);
+
+		return ResponseEntity.ok(ResponseData.builder()
+							 .code("200")
+							 .message("일정 추가에 성공했습니다.")
+							 .items(Collections.emptyList())
+							 .build());
+	}
+	
+	@GetMapping("/{scheduleNo}")
+	public ResponseEntity<ResponseData> findSchedule(@PathVariable("scheduleNo") Long scheduleNo) {
+	    ScheduleDTO schedule = scheduleService.findScheduleById(scheduleNo);
+	    return ResponseEntity.ok(ResponseData.builder()
+	            .code("200")
+	            .message("일정 상세 조회 성공")
+	            .items(Collections.singletonList(schedule))  // 단일 일정도 리스트로 감싸기
+	            .build());
+	}
+	
+	
+	@PostMapping("/update")
+	public ResponseEntity<ResponseData> updateSchedule(@RequestBody @Valid ScheduleDTO scheduleDTO) {
+		scheduleService.updateSchedule(scheduleDTO);
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("일정 수정 완료")
+				.items(Collections.emptyList())
+				.build());
+	}
+	
+	@DeleteMapping("/{scheduleNo}")
+	public ResponseEntity<ResponseData> deleteSection(@PathVariable("scheduleNo") Long scheduleNo) {
+		scheduleService.deleteSchedule(scheduleNo);
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("일정이 성공적으로 삭제되었습니다.")
+				.items(Collections.emptyList())
+				.build());
+	}
+	
+	
+
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/dao/ScheduleMapper.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/dao/ScheduleMapper.java
@@ -3,6 +3,7 @@ package com.kh.dotogether.schedule.model.dao;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.kh.dotogether.schedule.model.dto.MoveScheduleRequest;
 import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
 
 @Mapper
@@ -15,6 +16,12 @@ public interface ScheduleMapper {
 	void updateSchedule(ScheduleDTO scheduleDTO);
 
 	void deleteSchedule(@Param("scheduleNo") Long scheduleNo, @Param("userNo") Long userNo);
+
+	void updateScheduleSection(@Param("targetSectionNo") Long targetSectionNo,
+							   @Param("scheduleNo") Long scheduleNo,
+							   @Param("userNo") Long userNo);
+
+	Long selectBaseSectionNoByUserNo(Long userNo);
 
 
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/dao/ScheduleMapper.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/dao/ScheduleMapper.java
@@ -1,5 +1,20 @@
 package com.kh.dotogether.schedule.model.dao;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+
+@Mapper
 public interface ScheduleMapper {
+
+	void insertSchedule(ScheduleDTO scheduleDTO);
+
+	ScheduleDTO findScheduleById(@Param("scheduleNo") Long scheduleNo, @Param("userNo") Long userNo);
+
+	void updateSchedule(ScheduleDTO scheduleDTO);
+
+	void deleteSchedule(@Param("scheduleNo") Long scheduleNo, @Param("userNo") Long userNo);
+
 
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/dto/MoveScheduleRequest.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/dto/MoveScheduleRequest.java
@@ -1,0 +1,19 @@
+package com.kh.dotogether.schedule.model.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class MoveScheduleRequest {
+	
+	private Long scheduleNo;
+	private Long targetSectionNo;
+}

--- a/src/main/java/com/kh/dotogether/schedule/model/dto/ScheduleDTO.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/dto/ScheduleDTO.java
@@ -20,6 +20,7 @@ import lombok.ToString;
 public class ScheduleDTO {
 
     private Long scheduleNo;
+    private Long userNo;  
     private Long sectionNo;
 
     @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")

--- a/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleService.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleService.java
@@ -1,5 +1,19 @@
 package com.kh.dotogether.schedule.model.service;
 
+import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+
+
+
+
 public interface ScheduleService {
+
+	void setSchedule(ScheduleDTO scheduleDTO);
+
+	ScheduleDTO findScheduleById(Long scheduleNo);
+
+	void updateSchedule(ScheduleDTO scheduleDTO);
+
+	void deleteSchedule(Long scheduleNo);
+
 
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleService.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleService.java
@@ -1,6 +1,9 @@
 package com.kh.dotogether.schedule.model.service;
 
+import com.kh.dotogether.schedule.model.dto.MoveScheduleRequest;
 import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+
+import jakarta.validation.Valid;
 
 
 
@@ -13,7 +16,11 @@ public interface ScheduleService {
 
 	void updateSchedule(ScheduleDTO scheduleDTO);
 
-	void deleteSchedule(Long scheduleNo);
+	void deleteSchedule(Long scheduleNo, Long userNo);
+
+	void updateScheduleSection(MoveScheduleRequest request);
+
+	void setScheduleInBaseSection(@Valid ScheduleDTO scheduleDTO);
 
 
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleServiceImpl.java
@@ -8,7 +8,11 @@ import com.kh.dotogether.auth.model.vo.CustomUserDetails;
 import com.kh.dotogether.exception.exceptions.CustomException;
 import com.kh.dotogether.global.enums.ErrorCode;
 import com.kh.dotogether.schedule.model.dao.ScheduleMapper;
+import com.kh.dotogether.schedule.model.dto.MoveScheduleRequest;
 import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+import com.kh.dotogether.section.model.dao.SectionMapper;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ScheduleServiceImpl implements ScheduleService{
 	
 	private final ScheduleMapper scheduleMapper;
+	private final SectionMapper sectionMapper;
 
 	@Override
 	public void setSchedule(ScheduleDTO scheduleDTO) {
@@ -30,6 +35,25 @@ public class ScheduleServiceImpl implements ScheduleService{
 		scheduleDTO.setUserNo(userNo);
 		scheduleMapper.insertSchedule(scheduleDTO);
 	}
+	
+	
+	@Override
+	public void setScheduleInBaseSection(ScheduleDTO scheduleDTO) {
+	    Long userNo = scheduleDTO.getUserNo();  // 컨트롤러에서 세팅한 userNo 사용
+
+	    // 기준 섹션 조회
+	    Long baseSectionNo = sectionMapper.selectBaseSectionNoByUserNo(userNo);
+	    if (baseSectionNo == null) {
+	        throw new CustomException(ErrorCode.BASE_SECTION_NOT_FOUND);
+	    }
+
+	    scheduleDTO.setSectionNo(baseSectionNo);
+	    scheduleMapper.insertSchedule(scheduleDTO);
+	}
+
+
+
+	
 
 	@Override
 	public ScheduleDTO findScheduleById(Long scheduleNo) {
@@ -54,11 +78,20 @@ public class ScheduleServiceImpl implements ScheduleService{
 	}
 	
 	@Override
-	public void deleteSchedule(Long scheduleNo) {
-		Long userNo = getCurrentUserNo();
+	public void deleteSchedule(Long scheduleNo, Long userNo) {
 		scheduleMapper.deleteSchedule(scheduleNo, userNo);
 	}
 
+	
+	@Override
+	public void updateScheduleSection(MoveScheduleRequest request) {
+		Long userNo = getCurrentUserNo();
+		Long scheduleNo = request.getScheduleNo();
+		Long targetSectionNo = request.getTargetSectionNo();
+		scheduleMapper.updateScheduleSection(targetSectionNo, scheduleNo, userNo);
+		
+	}
+	
 	
 	private Long getCurrentUserNo() {
 		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -67,4 +100,9 @@ public class ScheduleServiceImpl implements ScheduleService{
 		}
 		throw new CustomException(ErrorCode.NOT_FOUND_USER);
 	}
+
+
+
+	
+	
 }

--- a/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/kh/dotogether/schedule/model/service/ScheduleServiceImpl.java
@@ -1,5 +1,70 @@
 package com.kh.dotogether.schedule.model.service;
 
-public class ScheduleServiceImpl {
 
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import com.kh.dotogether.auth.model.vo.CustomUserDetails;
+import com.kh.dotogether.exception.exceptions.CustomException;
+import com.kh.dotogether.global.enums.ErrorCode;
+import com.kh.dotogether.schedule.model.dao.ScheduleMapper;
+import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleServiceImpl implements ScheduleService{
+	
+	private final ScheduleMapper scheduleMapper;
+
+	@Override
+	public void setSchedule(ScheduleDTO scheduleDTO) {
+		String title = scheduleDTO.getScheduleTitle();
+		Long userNo = getCurrentUserNo();
+		
+		scheduleDTO.setScheduleTitle(title);
+		scheduleDTO.setSectionNo(scheduleDTO.getSectionNo());
+		scheduleDTO.setUserNo(userNo);
+		scheduleMapper.insertSchedule(scheduleDTO);
+	}
+
+	@Override
+	public ScheduleDTO findScheduleById(Long scheduleNo) {
+		Long userNo = getCurrentUserNo();
+		ScheduleDTO schedule = scheduleMapper.findScheduleById(scheduleNo, userNo);
+		
+		if(schedule == null) {
+			throw new CustomException(ErrorCode.SCHEDULE_NOT_FOUND);
+		}
+		return schedule;
+	}
+
+
+	@Override
+	public void updateSchedule(ScheduleDTO scheduleDTO) {
+		String scheduleTitle = scheduleDTO.getScheduleTitle();
+		
+		if(scheduleTitle.isBlank()) {
+			throw new CustomException(ErrorCode.EMPTY_TITLE);
+		}
+		scheduleMapper.updateSchedule(scheduleDTO);
+	}
+	
+	@Override
+	public void deleteSchedule(Long scheduleNo) {
+		Long userNo = getCurrentUserNo();
+		scheduleMapper.deleteSchedule(scheduleNo, userNo);
+	}
+
+	
+	private Long getCurrentUserNo() {
+		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		if (principal instanceof CustomUserDetails userDetails) {
+			return userDetails.getUserNo();
+		}
+		throw new CustomException(ErrorCode.NOT_FOUND_USER);
+	}
 }

--- a/src/main/java/com/kh/dotogether/section/controller/SectionController.java
+++ b/src/main/java/com/kh/dotogether/section/controller/SectionController.java
@@ -1,6 +1,7 @@
 package com.kh.dotogether.section.controller;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,67 +31,65 @@ public class SectionController {
 	private final SectionService sectionService;
 
 	@PostMapping
-	public ResponseEntity<ResponseData> setSection(
-			@RequestBody @Valid SectionDTO sectionDTO,
-		    @RequestHeader("Authorization") String authorizationHeader) {
-
-		sectionService.setSection(sectionDTO, authorizationHeader);
-
+	public ResponseEntity<ResponseData> setSection(@RequestBody @Valid SectionDTO sectionDTO) {
+		sectionService.setSection(sectionDTO);
 		return ResponseEntity.ok(ResponseData.builder()
-							 .code("200")
-							 .message("섹션 추가에 성공했습니다.")
-							 .items(Collections.emptyList())
-							 .build());
+				.code("200")
+				.message("섹션 추가에 성공했습니다.")
+				.items(Collections.emptyList())
+				.build());
 	}
 
 	@GetMapping("/check-title")
-	public ResponseEntity<ResponseData> checkSectionTitle(
-			@RequestParam("sectionTitle") String sectionTitle,
-			@RequestHeader("Authorization") String authorizationHeader) {
-
-		boolean exists = sectionService.existsByTitle(sectionTitle, authorizationHeader);
-
+	public ResponseEntity<ResponseData> checkSectionTitle(@RequestParam("sectionTitle") String sectionTitle) {
+		boolean exists = sectionService.existsByTitle(sectionTitle);
 		String message = exists ? "중복된 제목이 존재합니다." : "사용 가능한 제목입니다.";
 		String code = exists ? "409" : "200";
-
-		return ResponseEntity
-				.ok(ResponseData.builder()
+		return ResponseEntity.ok(ResponseData.builder()
 				.code(code)
 				.message(message)
 				.items(Collections.emptyList())
 				.build());
 	}
 
+	@GetMapping("/dashboard")
+	public ResponseEntity<ResponseData> findAllSectionsWithSchedules() {
+		List<SectionDTO> sections = sectionService.findAllSectionsWithSchedules();
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("섹션 및 일정 전체 조회 성공")
+				.items(sections)
+				.build());
+	}
+
+	@GetMapping("/{sectionNo}")
+	public ResponseEntity<ResponseData> getSectionWithSchedules(@PathVariable("sectionNo") Long sectionNo) {
+		SectionDTO section = sectionService.findSectionWithSchedules(sectionNo);
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("섹션 및 스케줄 조회 완료")
+				.items(List.of(section))
+				.build());
+	}
+
 	@PostMapping("/title-update")
-	public ResponseEntity<ResponseData> updateSectionTitle(
-			@RequestBody @Valid SectionDTO sectionDTO,
-			@RequestHeader("Authorization") String authorizationHeader) {
-
-		sectionService.updateSectionTitle(sectionDTO, authorizationHeader);
-
-		return ResponseEntity
-				.ok(ResponseData.builder()
+	public ResponseEntity<ResponseData> updateSectionTitle(@RequestBody @Valid SectionDTO sectionDTO) {
+		sectionService.updateSectionTitle(sectionDTO);
+		return ResponseEntity.ok(ResponseData.builder()
 				.code("200")
 				.message("제목 수정 완료")
 				.items(Collections.emptyList())
 				.build());
 	}
-	
+
 	@DeleteMapping("/{sectionNo}")
-	public ResponseEntity<ResponseData> deleteSection(
-	        @PathVariable("sectionNo") Long sectionNo,
-	        @RequestHeader("Authorization") String authorizationHeader) {
-
-	    sectionService.deleteSection(sectionNo, authorizationHeader);
-
-	    return ResponseEntity.ok(ResponseData.builder()
-	            .code("200")
-	            .message("섹션이 성공적으로 삭제되었습니다.")
-	            .items(Collections.emptyList())
-	            .build());
+	public ResponseEntity<ResponseData> deleteSection(@PathVariable("sectionNo") Long sectionNo) {
+		sectionService.deleteSection(sectionNo);
+		return ResponseEntity.ok(ResponseData.builder()
+				.code("200")
+				.message("섹션이 성공적으로 삭제되었습니다.")
+				.items(Collections.emptyList())
+				.build());
 	}
-	
-	
-	
-	
 }
+

--- a/src/main/java/com/kh/dotogether/section/controller/SectionController.java
+++ b/src/main/java/com/kh/dotogether/section/controller/SectionController.java
@@ -4,16 +4,17 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kh.dotogether.auth.model.vo.CustomUserDetails;
 import com.kh.dotogether.section.model.dto.SectionDTO;
 import com.kh.dotogether.section.model.service.SectionService;
 import com.kh.dotogether.util.ResponseData;
@@ -28,68 +29,106 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SectionController {
 
-	private final SectionService sectionService;
+    private final SectionService sectionService;
 
-	@PostMapping
-	public ResponseEntity<ResponseData> setSection(@RequestBody @Valid SectionDTO sectionDTO) {
-		sectionService.setSection(sectionDTO);
-		return ResponseEntity.ok(ResponseData.builder()
-				.code("200")
-				.message("섹션 추가에 성공했습니다.")
-				.items(Collections.emptyList())
-				.build());
-	}
+    // 섹션 추가
+    @PostMapping
+    public ResponseEntity<ResponseData> addSection(
+            @AuthenticationPrincipal CustomUserDetails userDetails, // 인증된 사용자 정보
+            @RequestBody @Valid SectionDTO sectionDTO) {
 
-	@GetMapping("/check-title")
-	public ResponseEntity<ResponseData> checkSectionTitle(@RequestParam("sectionTitle") String sectionTitle) {
-		boolean exists = sectionService.existsByTitle(sectionTitle);
-		String message = exists ? "중복된 제목이 존재합니다." : "사용 가능한 제목입니다.";
-		String code = exists ? "409" : "200";
-		return ResponseEntity.ok(ResponseData.builder()
-				.code(code)
-				.message(message)
-				.items(Collections.emptyList())
-				.build());
-	}
+        Long userNo = userDetails.getUserNo();
+        sectionDTO.setUserNo(userNo); // 서버가 userNo 강제 주입
 
-	@GetMapping("/dashboard")
-	public ResponseEntity<ResponseData> findAllSectionsWithSchedules() {
-		List<SectionDTO> sections = sectionService.findAllSectionsWithSchedules();
-		return ResponseEntity.ok(ResponseData.builder()
-				.code("200")
-				.message("섹션 및 일정 전체 조회 성공")
-				.items(sections)
-				.build());
-	}
+        SectionDTO newSection = sectionService.setSection(sectionDTO);
 
-	@GetMapping("/{sectionNo}")
-	public ResponseEntity<ResponseData> getSectionWithSchedules(@PathVariable("sectionNo") Long sectionNo) {
-		SectionDTO section = sectionService.findSectionWithSchedules(sectionNo);
-		return ResponseEntity.ok(ResponseData.builder()
-				.code("200")
-				.message("섹션 및 스케줄 조회 완료")
-				.items(List.of(section))
-				.build());
-	}
+        return ResponseEntity.ok(ResponseData.builder()
+                .code("200")
+                .message("섹션 추가에 성공했습니다.")
+                .items(List.of(newSection))
+                .build());
+    }
 
-	@PostMapping("/title-update")
-	public ResponseEntity<ResponseData> updateSectionTitle(@RequestBody @Valid SectionDTO sectionDTO) {
-		sectionService.updateSectionTitle(sectionDTO);
-		return ResponseEntity.ok(ResponseData.builder()
-				.code("200")
-				.message("제목 수정 완료")
-				.items(Collections.emptyList())
-				.build());
-	}
+    @GetMapping("/check-title")
+    public ResponseEntity<ResponseData> checkSectionTitle(
+            @RequestParam("sectionTitle") String sectionTitle,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-	@DeleteMapping("/{sectionNo}")
-	public ResponseEntity<ResponseData> deleteSection(@PathVariable("sectionNo") Long sectionNo) {
-		sectionService.deleteSection(sectionNo);
-		return ResponseEntity.ok(ResponseData.builder()
-				.code("200")
-				.message("섹션이 성공적으로 삭제되었습니다.")
-				.items(Collections.emptyList())
-				.build());
-	}
+        Long userNo = userDetails.getUserNo();
+
+        boolean exists = sectionService.existsByTitle(sectionTitle, userNo);
+        String message = exists ? "중복된 제목이 존재합니다." : "사용 가능한 제목입니다.";
+        String code = exists ? "409" : "200";
+
+        return ResponseEntity.ok(ResponseData.builder()
+                .code(code)
+                .message(message)
+                .items(Collections.emptyList())
+                .build());
+    }
+
+    // 내 섹션 및 일정 전체 조회
+    @GetMapping("/dashboard")
+    public ResponseEntity<ResponseData> findAllSectionsWithSchedules(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userNo = userDetails.getUserNo();
+        List<SectionDTO> sections = sectionService.findAllSectionsWithSchedules(userNo);
+
+        return ResponseEntity.ok(ResponseData.builder()
+                .code("200")
+                .message("섹션 및 일정 전체 조회 성공")
+                .items(sections)
+                .build());
+    }
+
+    // 특정 섹션 조회 (내 소유 섹션인지 꼭 체크 필요)
+    @GetMapping("/{sectionNo}")
+    public ResponseEntity<ResponseData> getSectionWithSchedules(
+            @PathVariable("sectionNo") Long sectionNo,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userNo = userDetails.getUserNo();
+        SectionDTO section = sectionService.findSectionWithSchedules(sectionNo, userNo);
+
+        return ResponseEntity.ok(ResponseData.builder()
+                .code("200")
+                .message("섹션 및 스케줄 조회 완료")
+                .items(List.of(section))
+                .build());
+    }
+
+    // 섹션 제목 수정
+    @PostMapping("/title-update")
+    public ResponseEntity<ResponseData> updateSectionTitle(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid SectionDTO sectionDTO) {
+
+        Long userNo = userDetails.getUserNo();
+        sectionDTO.setUserNo(userNo);
+
+        sectionService.updateSectionTitle(sectionDTO);
+
+        return ResponseEntity.ok(ResponseData.builder()
+                .code("200")
+                .message("제목 수정 완료")
+                .items(Collections.emptyList())
+                .build());
+    }
+
+    // 섹션 삭제
+    @DeleteMapping("/{sectionNo}")
+    public ResponseEntity<ResponseData> deleteSection(
+            @PathVariable("sectionNo") Long sectionNo,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userNo = userDetails.getUserNo();
+        sectionService.deleteSection(sectionNo, userNo);
+
+        return ResponseEntity.ok(ResponseData.builder()
+                .code("200")
+                .message("섹션이 성공적으로 삭제되었습니다.")
+                .items(Collections.emptyList())
+                .build());
+    }
 }
-

--- a/src/main/java/com/kh/dotogether/section/model/dao/SectionMapper.java
+++ b/src/main/java/com/kh/dotogether/section/model/dao/SectionMapper.java
@@ -34,13 +34,15 @@ public interface SectionMapper {
 								@Param("sectionNo") Long sectionNo, 
 								@Param("userNo") Long userNo);
 
-	SectionDTO findSectionByNo(Long sectionNo);
+	SectionDTO findSectionByNo(@Param("sectionNo") Long sectionNo, @Param("userNo") Long userNo);
 
 	List<ScheduleDTO> findSchedulesBySectionNo(Long sectionNo);
 
 	List<SectionDTO> findAllSectionWithSchedule(Long userNo);
 
 	SectionDTO findSectionWithSchedules(@Param("sectionNo") Long sectionNo, @Param("userNo") Long userNo);
+
+	Long selectBaseSectionNoByUserNo(Long userNo);
 
 
 	

--- a/src/main/java/com/kh/dotogether/section/model/dao/SectionMapper.java
+++ b/src/main/java/com/kh/dotogether/section/model/dao/SectionMapper.java
@@ -1,8 +1,11 @@
 package com.kh.dotogether.section.model.dao;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
 import com.kh.dotogether.section.model.dto.SectionDTO;
 
 @Mapper
@@ -21,11 +24,25 @@ public interface SectionMapper {
 
 	int findBySection(Long userNo);
 
-	SectionDTO findLastestSection(Long sectionNo);
+    SectionDTO findLastestSection(@Param("sectionNo") Long sectionNo, @Param("userNo") Long userNo);
 
 	void updateBaseSection(SectionDTO oldSection);
 
 	void deleteSection(Long sectionNo);
+
+	void moveSchedulesToSection(@Param("newSectionNo") Long newSectionNo, 
+								@Param("sectionNo") Long sectionNo, 
+								@Param("userNo") Long userNo);
+
+	SectionDTO findSectionByNo(Long sectionNo);
+
+	List<ScheduleDTO> findSchedulesBySectionNo(Long sectionNo);
+
+	List<SectionDTO> findAllSectionWithSchedule(Long userNo);
+
+	SectionDTO findSectionWithSchedules(@Param("sectionNo") Long sectionNo, @Param("userNo") Long userNo);
+
+
 	
 	
 

--- a/src/main/java/com/kh/dotogether/section/model/dto/SectionDTO.java
+++ b/src/main/java/com/kh/dotogether/section/model/dto/SectionDTO.java
@@ -28,6 +28,4 @@ public class SectionDTO {
 	private String isBaseSection;
 	private String createdAt;
 	private List<ScheduleDTO> schedules;
-	
-
 }

--- a/src/main/java/com/kh/dotogether/section/model/service/SectionService.java
+++ b/src/main/java/com/kh/dotogether/section/model/service/SectionService.java
@@ -1,49 +1,25 @@
 package com.kh.dotogether.section.model.service;
 
+import java.util.List;
+
 import com.kh.dotogether.section.model.dto.SectionDTO;
 
 
 public interface SectionService {
 
-	/**
-	 * 섹션 추가
-	 * @param sectionDTO
-	 */
-	void setSection(SectionDTO sectionDTO, String authorizationHeader);
-	
-	
-	/**
-	 * 섹션 제목(sectionTitle) 중복 확인
-	 * @param sectionTitle
-	 * @return true => 중복, false => 사용 가능
-	 */	
-	
-	boolean existsByTitle(String sectionTitle, String authorizationHeader);
-	
-	/**
-	 * isBaseSection이 'Y'인지 확인
-	 * @param isBaseSection
-	 * @return true => 기준섹션 존재 isBaseSection 'N'설정
-	 * 		   false => 기준섹션 존재 X isBaseSection 'Y' 설정
-	 */
-
-	/**
-	 * 
-	 * @param sectionTitle
-	 * @param userNo
-	 */
-	void updateSectionTitle(SectionDTO sectionDTO, String authorizationHeader);
-	
-	
-	
+	void setSection(SectionDTO sectionDTO);
+	boolean existsByTitle(String sectionTitle);
+	void updateSectionTitle(SectionDTO sectionDTO);
 	boolean existsBaseSection(Long userNo);
-
-	
-
-	void deleteSection(Long sectionNo, String authorizationHeader);
-
-
-	
-	
-
+	void deleteSection(Long sectionNo);
+	List<SectionDTO> findAllSectionsWithSchedules();
+	SectionDTO findSectionWithSchedules(Long sectionNo);
 }
+
+
+
+
+
+	
+	
+

--- a/src/main/java/com/kh/dotogether/section/model/service/SectionService.java
+++ b/src/main/java/com/kh/dotogether/section/model/service/SectionService.java
@@ -7,13 +7,14 @@ import com.kh.dotogether.section.model.dto.SectionDTO;
 
 public interface SectionService {
 
-	void setSection(SectionDTO sectionDTO);
-	boolean existsByTitle(String sectionTitle);
+	SectionDTO setSection(SectionDTO sectionDTO);
+	boolean existsByTitle(String sectionTitle, Long userNo);
+	List<SectionDTO> findAllSectionsWithSchedules(Long userNo);
+	SectionDTO findSectionWithSchedules(Long sectionNo, Long userNo);
 	void updateSectionTitle(SectionDTO sectionDTO);
 	boolean existsBaseSection(Long userNo);
-	void deleteSection(Long sectionNo);
-	List<SectionDTO> findAllSectionsWithSchedules();
-	SectionDTO findSectionWithSchedules(Long sectionNo);
+	void deleteSection(Long sectionNo, Long userNo);
+	SectionDTO findSectionByNo(Long newSectionNo, Long userNo);
 }
 
 

--- a/src/main/java/com/kh/dotogether/section/model/service/SectionServiceImpl.java
+++ b/src/main/java/com/kh/dotogether/section/model/service/SectionServiceImpl.java
@@ -1,12 +1,13 @@
 package com.kh.dotogether.section.model.service;
 
+import java.util.List;
+
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import com.kh.dotogether.auth.util.JWTUtil;
+import com.kh.dotogether.auth.model.vo.CustomUserDetails;
 import com.kh.dotogether.exception.exceptions.CustomException;
 import com.kh.dotogether.global.enums.ErrorCode;
-import com.kh.dotogether.member.model.dto.MemberDTO;
-import com.kh.dotogether.member.model.service.MemberService;
 import com.kh.dotogether.schedule.model.dto.ScheduleDTO;
 import com.kh.dotogether.section.model.dao.SectionMapper;
 import com.kh.dotogether.section.model.dto.SectionDTO;
@@ -20,52 +21,35 @@ import lombok.extern.slf4j.Slf4j;
 public class SectionServiceImpl implements SectionService {
 
 	private final SectionMapper sectionMapper;
-	private final MemberService memberService;
-	private final JWTUtil jwtUtil;
 
 	@Override
-	public void setSection(SectionDTO sectionDTO, String authorizationHeader) {
-		Long userNo = extractUserNo(authorizationHeader);
+	public void setSection(SectionDTO sectionDTO) {
+		Long userNo = getCurrentUserNo();
 
 		String title = sectionDTO.getSectionTitle();
-
-		if (title.isBlank()) {
-			throw new CustomException(ErrorCode.EMPTY_TITLE);
-		}
-
-		if (existsByTitle(title, authorizationHeader)) {
-			throw new CustomException(ErrorCode.DUPLICATE_SECTION_TITLE);
-		}
+		if (title.isBlank()) throw new CustomException(ErrorCode.EMPTY_TITLE);
+		if (existsByTitle(title)) throw new CustomException(ErrorCode.DUPLICATE_SECTION_TITLE);
 
 		sectionDTO.setUserNo(userNo);
-
-		if (existsBaseSection(userNo)) {
-			sectionDTO.setIsBaseSection("N");
-		} else {
-			sectionDTO.setIsBaseSection("Y");
-		}
+		sectionDTO.setIsBaseSection(existsBaseSection(userNo) ? "N" : "Y");
 
 		sectionMapper.insertSection(sectionDTO);
 	}
 
 	@Override
-	public boolean existsByTitle(String sectionTitle, String authorizationHeader) {
-		Long userNo = extractUserNo(authorizationHeader);
+	public boolean existsByTitle(String sectionTitle) {
+		Long userNo = getCurrentUserNo();
 		return sectionMapper.existsByTitle(sectionTitle, userNo) > 0;
 	}
 
 	@Override
-	public void updateSectionTitle(SectionDTO sectionDTO, String authorizationHeader) {
-		Long userNo = extractUserNo(authorizationHeader);
+	public void updateSectionTitle(SectionDTO sectionDTO) {
+		Long userNo = getCurrentUserNo();
 		String title = sectionDTO.getSectionTitle();
 		Long sectionNo = sectionDTO.getSectionNo();
 
-		if (title.isBlank()) {
-			throw new CustomException(ErrorCode.EMPTY_TITLE);
-		}
-		if (existsByTitle(title, authorizationHeader)) {
-			throw new CustomException(ErrorCode.DUPLICATE_SECTION_TITLE);
-		}
+		if (title.isBlank()) throw new CustomException(ErrorCode.EMPTY_TITLE);
+		if (existsByTitle(title)) throw new CustomException(ErrorCode.DUPLICATE_SECTION_TITLE);
 
 		sectionMapper.updateSectionTitle(title, userNo, sectionNo);
 	}
@@ -74,71 +58,90 @@ public class SectionServiceImpl implements SectionService {
 	public boolean existsBaseSection(Long userNo) {
 		return sectionMapper.countBaseSection(userNo) > 0;
 	}
-	
-	
-	
+
 	@Override
-	public void deleteSection(Long sectionNo, String authorizationHeader) {
-		Long userNo = extractUserNo(authorizationHeader);
-		
-		int sectionCount = sectionMapper.findBySection(userNo);
-		log.info("조회된 섹션 갯수 : {}", sectionCount);
-		
-		if(sectionCount == 0) {	// 섹션이 존재하지 않을 때
-			throw new CustomException(ErrorCode.SECTION_NOT_FOUND);
-		}
-		log.info("조회된 섹션 갯수 : {}", sectionCount);
-		
-		if(sectionCount == 1) {	//섹션이 하나 남았을 때
-			throw new CustomException(ErrorCode.CANNOT_DELETE_LAST_SECTION);
-		}
-		log.info("조회된 섹션 갯수 : {}", sectionCount);
-		
-		reassignBaseAndDelete(sectionNo, userNo);
-		
-	}
-	
-	
-	// 스케줄 이동 메서드
-	private void moveSchedulesToSection(ScheduleDTO scheduleDTO) {
-		
-		
-	}
-	
-	
-	/**
-	 * 기준 섹션으로 업데이트 및 기존 섹션 삭제
-	 * @param sectionNo
-	 * @param userNo
-	 */
-	private void reassignBaseAndDelete(Long sectionNo, Long userNo) {
-		SectionDTO newBaseSection = findLastestSection(sectionNo);
-		newBaseSection.setIsBaseSection("Y");
-		newBaseSection.setUserNo(userNo);
-		
-		sectionMapper.updateBaseSection(newBaseSection);
-		log.info("기준 섹션으로 승격 : {}", newBaseSection);
-		
-		sectionMapper.deleteSection(sectionNo);
-	}
-	
-	/**
-	 * 해당 섹션 다음으로 생성된 섹션
-	 * @param sectionNo
-	 * @return 
-	 */
-	private SectionDTO findLastestSection(Long sectionNo) {
-		SectionDTO newBaseSection = sectionMapper.findLastestSection(sectionNo);
-		return newBaseSection;
-	}
-	
-	
-	private Long extractUserNo(String authorizationHeader) {
-		String token = authorizationHeader.replace("Bearer ", "");
-		String userId = jwtUtil.getUserIdFromToken(token);
-		MemberDTO member = memberService.findByUserId(userId);
-		return member.getUserNo();
+	public List<SectionDTO> findAllSectionsWithSchedules() {
+		Long userNo = getCurrentUserNo();
+		return sectionMapper.findAllSectionWithSchedule(userNo);
 	}
 
-	
+	@Override
+	public SectionDTO findSectionWithSchedules(Long sectionNo) {
+		Long userNo = getCurrentUserNo();
+		SectionDTO section = sectionMapper.findSectionWithSchedules(sectionNo, userNo);
+		if (section == null) throw new CustomException(ErrorCode.SECTION_NOT_FOUND);
+		return section;
+	}
+
+	@Override
+	public void deleteSection(Long sectionNo) {
+	    Long userNo = getCurrentUserNo();
+	    
+	    // 핵심 디버깅 로그
+	    log.info("=== 섹션 삭제 디버깅 ===");
+	    log.info("getCurrentUserNo() 결과: {}", userNo);
+	    log.info("삭제할 섹션 번호: {}", sectionNo);
+	    
+	    SectionDTO sectionDTO = getSectionWithSchedules(sectionNo);
+	    int sectionCount = sectionMapper.findBySection(userNo);
+	    
+	    log.info("DB에서 조회한 섹션 개수 (USER_NO={}): {}", userNo, sectionCount);
+	    
+	    // 추가 확인: 실제 81 유저의 섹션 개수도 확인
+	    int actualCount = sectionMapper.findBySection(81L);
+	    log.info("실제 81 유저 섹션 개수: {}", actualCount);
+	    
+	    if (sectionCount == 0) throw new CustomException(ErrorCode.SECTION_NOT_FOUND);
+	    if (sectionCount == 1) throw new CustomException(ErrorCode.CANNOT_DELETE_LAST_SECTION);
+
+		SectionDTO newBaseSection = findLastestSection(sectionNo, userNo); 
+		log.info("다음으로 생성된 섹션 번호 : {}", newBaseSection);
+
+		moveSchedulesToSection(sectionDTO, userNo, newBaseSection);
+
+		if ("Y".equals(sectionDTO.getIsBaseSection())) {
+			reassignBaseAndDelete(sectionNo, userNo, newBaseSection);
+		} else {
+			sectionMapper.deleteSection(sectionNo);
+		}
+	}
+
+
+	private SectionDTO getSectionWithSchedules(Long sectionNo) {
+		SectionDTO section = sectionMapper.findSectionByNo(sectionNo);
+		List<ScheduleDTO> schedules = sectionMapper.findSchedulesBySectionNo(sectionNo);
+		section.setSchedules(schedules);
+		return section;
+	}
+
+	private void moveSchedulesToSection(SectionDTO sectionDTO, Long userNo, SectionDTO newBaseSection) {
+		List<ScheduleDTO> schedules = sectionDTO.getSchedules();
+		Long sectionNo = sectionDTO.getSectionNo();
+		Long newSectionNo = newBaseSection.getSectionNo();
+
+		if (schedules != null && !schedules.isEmpty()) {
+			sectionMapper.moveSchedulesToSection(newSectionNo, sectionNo, userNo);
+		}
+	}
+
+	private void reassignBaseAndDelete(Long sectionNo, Long userNo, SectionDTO newBaseSection) {
+		newBaseSection.setIsBaseSection("Y");
+		newBaseSection.setUserNo(userNo);
+		sectionMapper.updateBaseSection(newBaseSection);
+		log.info("기준 섹션으로 승격 : {}", newBaseSection);
+		sectionMapper.deleteSection(sectionNo);
+	}
+
+	private SectionDTO findLastestSection(Long sectionNo, Long userNo) {
+		return sectionMapper.findLastestSection(sectionNo, userNo);
+	}
+
+	private Long getCurrentUserNo() {
+		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		if (principal instanceof CustomUserDetails userDetails) {
+			return userDetails.getUserNo();
+		}
+		throw new CustomException(ErrorCode.NOT_FOUND_USER);
+	}
 }
+

--- a/src/main/resources/mapper/schedule-mapper.xml
+++ b/src/main/resources/mapper/schedule-mapper.xml
@@ -4,19 +4,29 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.kh.dotogether.schedule.model.dao.ScheduleMapper">
 
-	<insert id="insertSchedule">
-		  INSERT INTO TB_SCHEDULE (
-			    SCHEDULE_NO,
-			    USER_NO,       
-			    SECTION_NO,
-			    SCHEDULE_TITLE
-			) VALUES (
-			    SEQ_SCHEDULE_NO.NEXTVAL,
-			    #{userNo},     
-			    #{sectionNo},
-			    #{scheduleTitle}
-	)
+	<insert id="insertSchedule" parameterType="ScheduleDTO">
+	  <selectKey resultType="long" keyProperty="scheduleNo" order="AFTER">
+	    SELECT SEQ_SCHEDULE_NO.CURRVAL FROM DUAL
+	  </selectKey>
+	
+	  INSERT INTO TB_SCHEDULE (
+	        SCHEDULE_NO,
+	        USER_NO,
+	        SECTION_NO,
+	        SCHEDULE_TITLE,
+	        START_DATE,
+	        DUE_DATE
+	  ) VALUES (
+	        SEQ_SCHEDULE_NO.NEXTVAL,
+	        #{userNo},
+	        #{sectionNo},
+	        #{scheduleTitle},
+	        #{startDate},
+	        #{dueDate}
+	  )
 	</insert>
+
+
 	
 	<select id="findScheduleById">
 		SELECT
@@ -62,6 +72,19 @@
 		AND
 			USER_NO = #{userNo}	
 	</delete>
+	
+	
+	<update id="updateScheduleSection">
+	    UPDATE 
+	    	TB_SCHEDULE
+	    SET 
+	    	SECTION_NO = #{targetSectionNo}
+	    WHERE 
+	    	SCHEDULE_NO = #{scheduleNo}
+	    AND 
+	    	USER_NO = #{userNo}
+	</update>
+
 	
 
 	

--- a/src/main/resources/mapper/schedule-mapper.xml
+++ b/src/main/resources/mapper/schedule-mapper.xml
@@ -4,5 +4,66 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.kh.dotogether.schedule.model.dao.ScheduleMapper">
 
+	<insert id="insertSchedule">
+		  INSERT INTO TB_SCHEDULE (
+			    SCHEDULE_NO,
+			    USER_NO,       
+			    SECTION_NO,
+			    SCHEDULE_TITLE
+			) VALUES (
+			    SEQ_SCHEDULE_NO.NEXTVAL,
+			    #{userNo},     
+			    #{sectionNo},
+			    #{scheduleTitle}
+	)
+	</insert>
+	
+	<select id="findScheduleById">
+		SELECT
+			SCHEDULE_NO,
+		    SECTION_NO,
+		    USER_NO,
+		    SCHEDULE_TITLE,
+		    SCHEDULE_CONTENT,
+		    START_DATE,
+		    DUE_DATE,
+		    IS_COMPLETED
+	    FROM
+	    	TB_SCHEDULE
+    	WHERE
+    		SCHEDULE_NO = #{scheduleNo}
+		AND
+			USER_NO = #{userNo}
+	</select>
+	
+	<update id="updateSchedule">
+		UPDATE
+			TB_SCHEDULE
+	    SET
+	   	  	SCHEDULE_TITLE = #{scheduleTitle},
+	   	  	SCHEDULE_CONTENT = #{scheduleContent},
+	   	  	START_DATE = #{startDate},
+	   	  	DUE_DATE = #{dueDate},
+	   	  	IS_COMPLETED = #{isCompleted}
+		WHERE
+	  		USER_NO = #{userNo}
+  		AND
+  			SCHEDULE_NO = #{scheduleNo}
+		AND
+			SECTION_NO = #{sectionNo}
+	</update>
+	
+	<delete id="deleteSchedule">
+		DELETE
+		  FROM
+	        TB_SCHEDULE
+		 WHERE
+        	SCHEDULE_NO = #{scheduleNo}        
+		AND
+			USER_NO = #{userNo}	
+	</delete>
+	
+
+	
 
 </mapper>

--- a/src/main/resources/mapper/section-mapper.xml
+++ b/src/main/resources/mapper/section-mapper.xml
@@ -4,14 +4,14 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.kh.dotogether.section.model.dao.SectionMapper">
 
-	<resultMap id="sectionWithSchedules" type="SectionDTO">
+	<resultMap id="sectionWithSchedules" type="com.kh.dotogether.section.model.dto.SectionDTO">
 	    <id property="sectionNo" column="SECTION_NO" />
 	    <result property="userNo" column="USER_NO"/>
 	    <result property="sectionTitle" column="SECTION_TITLE"/>
 	    <result property="isBaseSection" column="IS_BASE_SECTION"/>
 	    <result property="createdAt" column="CREATED_AT"/>
 	    
-	    <collection property="schedules" ofType="ScheduleDTO">
+	    <collection property="schedules" ofType="com.kh.dotogether.schedule.model.dto.ScheduleDTO">
 	        <id property="scheduleNo" column="SCHEDULE_NO"/>
 	        <result property="scheduleTitle" column="SCHEDULE_TITLE"/>
 	        <result property="scheduleContent" column="SCHEDULE_CONTENT"/>
@@ -19,6 +19,7 @@
 	        <result property="dueDate" column="DUE_DATE"/>
 	    </collection>
 	</resultMap>
+
 
 
 	<!--섹션 제목 중복체크-->
@@ -45,20 +46,39 @@
 			USER_NO = #{userNo}
 	</select>
 	
+	
+	<select id="selectBaseSectionNoByUserNo" resultType="long">
+		  SELECT 
+		  	SECTION_NO
+		  FROM 
+		  	TB_SECTION
+		  WHERE 
+		  	USER_NO = #{userNo}
+	      AND 
+	      	IS_BASE_SECTION = 'Y'
+		  FETCH 
+		  	FIRST 1 ROWS ONLY
+	</select>
+	
 	<!--섹션 추가-->
-	<insert id="insertSection">
-		INSERT INTO TB_SECTION (
-		    SECTION_NO,
-		    USER_NO,
-		    SECTION_TITLE,
-		    IS_BASE_SECTION
-		) VALUES (
-		    SEQ_SECTION_NO.NEXTVAL,
-		    #{userNo},
-		    #{sectionTitle},
-		    #{isBaseSection}
-		)
+	<insert id="insertSection" parameterType="SectionDTO" keyProperty="sectionNo" keyColumn="SECTION_NO">
+	    <selectKey keyProperty="sectionNo" resultType="long" order="BEFORE">
+	        SELECT SEQ_SECTION_NO.NEXTVAL FROM DUAL
+	    </selectKey>
+	    
+	    INSERT INTO TB_SECTION (
+	        SECTION_NO,
+	        USER_NO,
+	        SECTION_TITLE,
+	        IS_BASE_SECTION
+	    ) VALUES (
+	        #{sectionNo},
+	        #{userNo},
+	        #{sectionTitle},
+	        #{isBaseSection}
+	    )
 	</insert>
+
 	
 	<update id="updateSectionTitle">
 		UPDATE
@@ -141,6 +161,7 @@
 			TB_SECTION
 		WHERE 
 			SECTION_NO = #{sectionNo}
+		AND USER_NO = #{userNo}
 	</select>
 	
 	<select id="findSchedulesBySectionNo" resultType="ScheduleDTO">

--- a/src/main/resources/mapper/section-mapper.xml
+++ b/src/main/resources/mapper/section-mapper.xml
@@ -4,6 +4,23 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.kh.dotogether.section.model.dao.SectionMapper">
 
+	<resultMap id="sectionWithSchedules" type="SectionDTO">
+	    <id property="sectionNo" column="SECTION_NO" />
+	    <result property="userNo" column="USER_NO"/>
+	    <result property="sectionTitle" column="SECTION_TITLE"/>
+	    <result property="isBaseSection" column="IS_BASE_SECTION"/>
+	    <result property="createdAt" column="CREATED_AT"/>
+	    
+	    <collection property="schedules" ofType="ScheduleDTO">
+	        <id property="scheduleNo" column="SCHEDULE_NO"/>
+	        <result property="scheduleTitle" column="SCHEDULE_TITLE"/>
+	        <result property="scheduleContent" column="SCHEDULE_CONTENT"/>
+	        <result property="startDate" column="START_DATE"/>
+	        <result property="dueDate" column="DUE_DATE"/>
+	    </collection>
+	</resultMap>
+
+
 	<!--섹션 제목 중복체크-->
 	<select id="existsByTitle" resultType="int">
 		SELECT
@@ -76,6 +93,8 @@
 				TB_SECTION
 			WHERE 
 				SECTION_NO != #{sectionNo}
+			AND 
+            	USER_NO = #{userNo}
 			ORDER BY 
 				CREATED_AT ASC
 		)
@@ -96,10 +115,94 @@
 	<delete id="deleteSection">
 		DELETE
 		  FROM
-		        TB_SECTION
+	        TB_SECTION
 		 WHERE
-	        	SECTION_NO = #{sectionNo}        	
+        	SECTION_NO = #{sectionNo}        	
 	</delete>
+	
+	<update id="moveSchedulesToSection">
+		UPDATE
+			TB_SCHEDULE
+	    SET
+	   	  	SECTION_NO = #{newSectionNo}
+		WHERE
+			SECTION_NO = #{sectionNo}
+		
+	</update>
+	
+	<select id="findSectionByNo" resultType="SectionDTO">
+		SELECT 
+			SECTION_NO, 
+			USER_NO, 
+			SECTION_TITLE, 
+			IS_BASE_SECTION, 
+			CREATED_AT
+		FROM 
+			TB_SECTION
+		WHERE 
+			SECTION_NO = #{sectionNo}
+	</select>
+	
+	<select id="findSchedulesBySectionNo" resultType="ScheduleDTO">
+		SELECT *
+		FROM 
+			TB_SCHEDULE
+		WHERE 
+			SECTION_NO = #{sectionNo}
+	</select>
+	
+	
+	<select id="findAllSectionWithSchedule" resultMap="sectionWithSchedules">
+	    SELECT 
+	        S.SECTION_NO,
+	        S.USER_NO,
+	        S.SECTION_TITLE,
+	        S.IS_BASE_SECTION,
+	        S.CREATED_AT,
+	        SCH.SCHEDULE_NO,
+	        SCH.SCHEDULE_TITLE,
+	        SCH.SCHEDULE_CONTENT,
+	        SCH.START_DATE,
+	        SCH.DUE_DATE
+	    FROM 
+	    	TB_SECTION S
+	    LEFT JOIN 
+	    	TB_SCHEDULE SCH 
+    	ON 
+    		S.SECTION_NO = SCH.SECTION_NO
+	    WHERE 
+	    	S.USER_NO = #{userNo}
+	    ORDER BY 
+	    	S.CREATED_AT
+	</select>
+	
+	<select id="findSectionWithSchedules" resultMap="sectionWithSchedules">
+		SELECT 
+		    S.SECTION_NO,
+		    S.USER_NO,
+		    S.SECTION_TITLE,
+		    S.IS_BASE_SECTION,
+		    S.CREATED_AT,
+		    SCH.SCHEDULE_NO,
+		    SCH.SCHEDULE_TITLE,
+		    SCH.SCHEDULE_CONTENT,
+		    SCH.START_DATE,
+		    SCH.DUE_DATE,
+		    SCH.IS_COMPLETED,
+		    SCH.CREATED_AT AS SCHEDULE_CREATED_AT
+		FROM 
+		    TB_SECTION S
+		LEFT JOIN 
+		    TB_SCHEDULE SCH 
+		ON 
+		    S.SECTION_NO = SCH.SECTION_NO
+		WHERE 
+		    S.SECTION_NO = #{sectionNo}
+		AND 
+		    S.USER_NO = #{userNo}
+	</select>
+
+
 	
 
 </mapper>


### PR DESCRIPTION
작성자 : 김영수
일자 : 2025-07-07 / 04:35

✅ 주요 작업 내용
대시보드에서 섹션 및 일정 관리 기능 전반 개선

캘린더 일정 추가 기능 완료

💡 Optimistic UI 방식 적용했습니다
기존에는 사용자가 일정을 생성하면,
서버에 요청을 보내고 응답을 받아야만 화면에 일정이 반영됐습니다.
그래서 중간에 약간의 딜레이가 발생하거나, 새로고침을 해야 제대로 보이는 문제가 있었습니다.

이를 개선하기 위해 이번에 Optimistic UI 방식을 도입했습니다.

작동 방식은 간단합니다:

사용자가 일정을 등록하면,
👉 서버 응답을 기다리지 않고 **임시 ID (temp_<timestamp>)**로 UI에 먼저 표시합니다.

서버에서 응답이 오면,
👉 해당 일정의 ID를 **실제 scheduleNo**로 바꿔줍니다.

만약 요청이 실패하면,
👉 UI에서 해당 임시 일정을 제거해 원래 상태로 되돌립니다.

이 방식을 통해 사용자는 일정이 바로 등록된 것처럼 느낄 수 있어서
피드백 속도도 빨라지고, 전반적인 UX도 많이 좋아졌습니다.

